### PR TITLE
Add missing 2 to pathfinding.md

### DIFF
--- a/lessons/pathfinding.md
+++ b/lessons/pathfinding.md
@@ -65,7 +65,7 @@ We'll do this until we intersect the two spirals. As soon as the spiral intersec
 
 ```
 2 1 2 • • •
-1 A 1 • • •
+1 A 1 2 • •
 2 1 2 • • •
 • X X X X X
 • • 1 • • •


### PR DESCRIPTION
@1Marc @btholt 
Doc was missing '2' in grid. Omission
was mentioned around 5:18 mark of
'Pathfinding & Demonstration' video
of FEM course.